### PR TITLE
Added getStoreDomain() to SallaUser

### DIFF
--- a/src/Provider/SallaUser.php
+++ b/src/Provider/SallaUser.php
@@ -167,6 +167,17 @@ class SallaUser implements ResourceOwnerInterface
     {
         return $this->getResponseValue('data.merchant.status');
     }
+    
+     /**
+     * Get store domain.
+     *
+     * @return string|null
+     */
+    public function getStoreDomain()
+    {
+        return $this->getResponseValue('data.merchant.domain');
+    }
+
 
     /**
      * Get store created at.


### PR DESCRIPTION
I was building an app using the Salla provider and I needed the merchant domain. I noticed this was included in the api but not in the package.