### PR TITLE
- added missing $option parameter

### DIFF
--- a/src/Provider/Salla.php
+++ b/src/Provider/Salla.php
@@ -152,7 +152,7 @@ class Salla extends AbstractProvider
             $token = $token->getToken();
         }
 
-        $request = $this->getAuthenticatedRequest($method, $url, $token);
+        $request = $this->getAuthenticatedRequest($method, $url, $token, $options);
 
         return $this->getParsedResponse($request);
     }


### PR DESCRIPTION
getAuthenticatedRequest method is missing $options parameters, which result in failure for all POST and PUT methods with response 'invalid_fields'.

This pull request is fixing this bug.