### PR TITLE
Fix typo: change redirectUri to redirectUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ use Salla\OAuth2\Client\Provider\Salla;
 $provider = new Salla([
     'clientId'     => '{client-id}', // The client ID assigned to you by Salla
     'clientSecret' => '{client-secret}', // The client password assigned to you by Salla
-    'redirectUri'  => 'https://yourservice.com/callback_url', // the url for current page in your service
+    'redirectUrl'  => 'https://yourservice.com/callback_url', // the url for current page in your service
 ]);
 
 /**


### PR DESCRIPTION
Example:
`https://accounts.salla.sa/oauth2/auth?scope=offline_access&state=9a0e6714a39a8d39597a1c65220614f2&response_type=code&approval_prompt=auto&redirect_uri=***&client_id=**`

Error:
`The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered redirect urls.`

redirect_uri is not a part of Salla's oauth2 parameters. The correct parameter is "redirect_url".

Note:
If "redirect_uri" is the official parameter, as stated in the docs and other auth tutorials, it could be a bug in the auth endpoint https://accounts.salla.sa/oauth2/auth where only accept redirect_url