### PR TITLE
fix(partners): Fix get user from cache

### DIFF
--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -50,7 +50,7 @@ class OauthMiddleware
 
         $exception_at = now()->diffInSeconds($this->user->getExpiredAt());
 
-        Cache::put($cacheKey, $this->user->toArray(), now()->addSeconds($exception_at));
+        Cache::put($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 
         return $this->nextRequest($next, $request);
     }


### PR DESCRIPTION
When try to get user info from cache it will search for data key and will throw error 

`User data not found`