### PR TITLE
fix(partners): Fix Laravel 11 Compatibility- Implement `getAuthPasswordName()` Method in OAuthUser Model

### DIFF
--- a/src/Models/OAuthUser.php
+++ b/src/Models/OAuthUser.php
@@ -34,6 +34,11 @@ class OAuthUser implements Authenticatable
         throw new \BadMethodCallException('Not available for OAuth users');
     }
 
+    public function getAuthPasswordName()
+    {
+        throw new \BadMethodCallException('Not available for OAuth users');
+    }
+
     public function getRememberToken()
     {
         throw new \BadMethodCallException('Not available for OAuth users');

--- a/test/OAuthUserTest.php
+++ b/test/OAuthUserTest.php
@@ -46,6 +46,12 @@ class OAuthUserTest extends TestCase
         $this->oauthUser->getAuthPassword();
     }
 
+    public function testGetAuthPasswordNameThrowsException()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->oauthUser->getAuthPasswordName();
+    }
+
     public function testGetRememberTokenThrowsException()
     {
         $this->expectException(\BadMethodCallException::class);


### PR DESCRIPTION
## Overview
This PR addresses compatibility issues with Laravel 11 for the `oauth2-merchant` package by implementing the `getAuthPasswordName()` method in the `OAuthUser` model.

## Problem
In Laravel 11, the `Authenticatable` contract introduces a new method `getAuthPasswordName()`. Models implementing this contract must provide an implementation of this method.

## Solution
We've added an implementation of `getAuthPasswordName()` to the `OAuthUser` model that throws a `BadMethodCallException` when invoked, since OAuth users do not have a traditional password:

```php
public function getAuthPasswordName()
{
    throw new \BadMethodCallException('Not available for OAuth users');
}
```

## Changes
- Implemented `getAuthPasswordName()` method in `OAuthUser` model
- Added test coverage for the new method implementation

## Reference
This change is based on the Laravel framework update: [Laravel Framework PR #48665](https://github.com/laravel/framework/pull/48665/files#diff-4d23e0b5cb4081869bfc6ab72e6677922fe37955a70d6825c43e785e7b0c8168)
