### PR TITLE
feat(partners): Support multiple scopes in middleware

### DIFF
--- a/test/OauthMiddlewareTest.php
+++ b/test/OauthMiddlewareTest.php
@@ -9,102 +9,17 @@ use Salla\OAuth2\Client\Provider\Salla;
 
 class OauthMiddlewareTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
+    private $userData;
+    private $token;
+    private $mockSalla;
+
+    protected function setUp(): void
     {
-        $app['router']->get('hello/user')->name('auth.user')->uses(function () {
-            return 'hello '. auth()->guard('salla-oauth')->user()->getAuthIdentifier();
-        })->middleware(OauthMiddleware::class);
+        parent::setUp();
 
-        $app['router']->get('hello/user-order-read-scope')->uses(function () {
-            return 'hello '. auth()->guard('salla-oauth')->user()->getAuthIdentifier();
-        })->middleware('salla.oauth:orders.read');
+        $this->token = new AccessToken(['access_token' => 'foobar']);
 
-        $app['router']->get('hello/guest')->name('auth.guest')->uses(function () {
-            return 'hello guest';
-        });
-    }
-
-    public function testUnAuthWhenTokenIsNotProvided()
-    {
-        /** @var \Illuminate\Testing\TestResponse|\Illuminate\Http\Response $response */
-        $response = $this->get('hello/user');
-        $response->assertStatus(401);
-    }
-
-    public function testUnAuthWhenTokenIsNotValid()
-    {
-        /** @var \Illuminate\Testing\TestResponse|\Illuminate\Http\Response $response */
-        $response = $this->get('hello/user', [
-            'Authorization' => 'Bearer foobar'
-        ]);
-        $response->assertStatus(401);
-    }
-
-    public function testAddsUserinfoToRequest()
-    {
-        $this->app->singleton(SallaOauth::class, function ()  {
-            return $this->getMockBuilder(Salla::class)
-                ->disableOriginalConstructor()
-                ->onlyMethods(['fetchResourceOwnerDetails'])
-                ->getMock();
-        });
-
-
-        // Mock response
-        $user = [
-            'data' => [
-                'id' => '12345',
-                'name' => 'mock name',
-                'email' => 'mock.name@example.com',
-                'mobile' => '05000000',
-                'role' => 'user',
-                'created_at' => '2018-04-28 17:46:25',
-                'merchant' => [
-                    'id' => '11111',
-                    'owner_id' => '12345',
-                    'owner_name' => 'mock name',
-                    'username' => 'mock_name',
-                    'name' => 'mock name',
-                    'avatar' => 'mock_avatar',
-                    'store_location' => 'mock_location',
-                    'plan' => 'mock_plan',
-                    'status' => 'mock_status',
-                    'created_at' => '2018-04-28 17:46:25',
-                ]
-            ]
-        ];
-
-        $token = new AccessToken([
-            'access_token' => 'foobar',
-        ]);
-
-        // Set up the expectation for fetchResourceOwnerDetails method
-        $this->app->make(SallaOauth::class)->expects($this->once())
-            ->method('fetchResourceOwnerDetails')
-            ->with($this->equalTo($token))
-            ->willReturn($user);
-
-        $response = $this->get('hello/user', [
-            'Authorization' => 'Bearer foobar'
-        ]);
-        $response->assertStatus(200)->assertSeeText('hello 12345');
-
-        $authGuard = auth()->guard('salla-oauth');
-        $this->assertTrue($authGuard->check());
-        $this->assertSame($user['data']['id'], $authGuard->user()->getAuthIdentifier());
-    }
-
-    public function testCheckAllowedUserScope()
-    {
-        $this->app->singleton(SallaOauth::class, function ()  {
-            return $this->getMockBuilder(Salla::class)
-                ->disableOriginalConstructor()
-                ->onlyMethods(['fetchResourceOwnerDetails'])
-                ->getMock();
-        });
-
-        // Mock response
-        $user = [
+        $this->userData = [
             'data' => [
                 'id' => '12345',
                 'name' => 'mock name',
@@ -131,74 +46,113 @@ class OauthMiddlewareTest extends TestCase
                 ]
             ]
         ];
-
-        $token = new AccessToken([
-            'access_token' => 'foobar',
-        ]);
-
-        // Set up the expectation for fetchResourceOwnerDetails method
-        $this->app->make(SallaOauth::class)->expects($this->once())
-            ->method('fetchResourceOwnerDetails')
-            ->with($this->equalTo($token))
-            ->willReturn($user);
-
-        $response = $this->get('hello/user-order-read-scope', [
-            'Authorization' => 'Bearer foobar'
-        ]);
-        $response->assertStatus(200)->assertSeeText('hello 12345');
     }
 
-    public function testCheckNotAllowedUserScope()
+    protected function getEnvironmentSetUp($app)
     {
-        $this->app->singleton(SallaOauth::class, function ()  {
+        $app['router']->get('hello/user')->name('auth.user')->uses(function () {
+            return 'hello ' . auth()->guard('salla-oauth')->user()->getAuthIdentifier();
+        })->middleware(OauthMiddleware::class);
+
+        $app['router']->get('hello/user-order-read-scope')->uses(function () {
+            return 'hello ' . auth()->guard('salla-oauth')->user()->getAuthIdentifier();
+        })->middleware('salla.oauth:orders.read');
+
+        $app['router']->get('hello/user-order-multiple-scopes')->uses(function () {
+            return 'hello ' . auth()->guard('salla-oauth')->user()->getAuthIdentifier();
+        })->middleware('salla.oauth:orders.read,orders.read_write');
+
+        $app['router']->get('hello/guest')->name('auth.guest')->uses(function () {
+            return 'hello guest';
+        });
+    }
+
+    protected function setupMockSalla($userData = null)
+    {
+        $this->app->singleton(SallaOauth::class, function () {
             return $this->getMockBuilder(Salla::class)
                 ->disableOriginalConstructor()
                 ->onlyMethods(['fetchResourceOwnerDetails'])
                 ->getMock();
         });
 
-        // Mock response
-        $user = [
-            'data' => [
-                'id' => '12345',
-                'name' => 'mock name',
-                'email' => 'mock.name@example.com',
-                'mobile' => '05000000',
-                'role' => 'user',
-                'created_at' => '2018-04-28 17:46:25',
-                'merchant' => [
-                    'id' => '11111',
-                    'owner_id' => '12345',
-                    'owner_name' => 'mock name',
-                    'username' => 'mock_name',
-                    'name' => 'mock name',
-                    'avatar' => 'mock_avatar',
-                    'store_location' => 'mock_location',
-                    'plan' => 'mock_plan',
-                    'status' => 'mock_status',
-                    'created_at' => '2018-04-28 17:46:25',
-                ],
-                'context' => [
-                    'app' => '123',
-                    'scope' => 'customers.read products.read',
-                    'exp' => 1721326955
-                ]
-            ]
-        ];
-
-        $token = new AccessToken([
-            'access_token' => 'foobar',
-        ]);
-
-        // Set up the expectation for fetchResourceOwnerDetails method
-        $this->app->make(SallaOauth::class)->expects($this->once())
+        $mockSalla = $this->app->make(SallaOauth::class);
+        $mockSalla->expects($this->once())
             ->method('fetchResourceOwnerDetails')
-            ->with($this->equalTo($token))
-            ->willReturn($user);
+            ->with($this->equalTo($this->token))
+            ->willReturn($userData ?? $this->userData);
 
-        $response = $this->get('hello/user-order-read-scope', [
-            'Authorization' => 'Bearer foobar'
-        ]);
+        return $mockSalla;
+    }
+
+    protected function makeAuthRequest($uri)
+    {
+        return $this->get($uri, ['Authorization' => 'Bearer foobar']);
+    }
+
+    public function testUnAuthWhenTokenIsNotProvided()
+    {
+        $response = $this->get('hello/user');
+        $response->assertStatus(401);
+    }
+
+    public function testUnAuthWhenTokenIsNotValid()
+    {
+        $response = $this->get('hello/user', ['Authorization' => 'Bearer foobar']);
+        $response->assertStatus(401);
+    }
+
+    public function testAddsUserinfoToRequest()
+    {
+        $this->setupMockSalla();
+
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+
+        $authGuard = auth()->guard('salla-oauth');
+        $this->assertTrue($authGuard->check());
+        $this->assertSame($this->userData['data']['id'], $authGuard->user()->getAuthIdentifier());
+    }
+
+    public function testCheckAllowedUserScope()
+    {
+        $this->setupMockSalla();
+
+        $response = $this->makeAuthRequest('hello/user-order-read-scope');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+    }
+
+    public function testCheckNotAllowedUserScope()
+    {
+        $userData = $this->userData;
+        $userData['data']['context']['scope'] = 'customers.read';
+
+        $this->setupMockSalla($userData);
+
+        $response = $this->makeAuthRequest('hello/user-order-read-scope');
         $response->assertStatus(401)->assertSeeText('Unauthorized');
+    }
+
+    public function testCheckAllowedUserMultipleScopes()
+    {
+        $userData = $this->userData;
+        $userData['data']['context']['scope'] = 'orders.read_write';
+        $this->setupMockSalla($userData);
+
+        $response = $this->makeAuthRequest('hello/user-order-multiple-scopes');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+    }
+
+    public function testCachedUser()
+    {
+        $userData = $this->userData;
+        $userData['data']['context'] = null;
+        $this->setupMockSalla($userData);
+
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+
+        $response = $this->makeAuthRequest('hello/user-order-read-scope');
+        $response->assertStatus(401);
     }
 }

--- a/test/OauthMiddlewareTest.php
+++ b/test/OauthMiddlewareTest.php
@@ -11,7 +11,6 @@ class OauthMiddlewareTest extends TestCase
 {
     private $userData;
     private $token;
-    private $mockSalla;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
- Features
   for now we only support one scope per middleware but in app if we select read_write this will support bot read and write and api will return only read_write scope not (read, read_write) 
   so if we have endpoint support both read and write will not work

- fixes
   user info is cached for the first time so will work ok with routes without scope but if token is cached and accessed route without scope it will pass