### PR TITLE
feat(CPD-25082): Support cache tags

### DIFF
--- a/config/salla-oauth.php
+++ b/config/salla-oauth.php
@@ -6,4 +6,5 @@ return [
     'redirect_url' => env('SALLA_OAUTH_CLIENT_REDIRECT_URI'),
     'base_url' => env('SALLA_OAUTH_BASE_URL', 'https://accounts.salla.sa'),
     'cache-prefix' => env('SALLA_OAUTH_PREFIX_CACHE', 'oauth'),
+    'cache-tag' => env('SALLA_OAUTH_CACHE_TAG', 'salla-oauth'),
 ];

--- a/config/salla-oauth.php
+++ b/config/salla-oauth.php
@@ -6,5 +6,5 @@ return [
     'redirect_url' => env('SALLA_OAUTH_CLIENT_REDIRECT_URI'),
     'base_url' => env('SALLA_OAUTH_BASE_URL', 'https://accounts.salla.sa'),
     'cache-prefix' => env('SALLA_OAUTH_PREFIX_CACHE', 'oauth'),
-    'cache-tag' => env('SALLA_OAUTH_CACHE_TAG', 'salla-oauth'),
+    'cache-tag' => env('SALLA_OAUTH_CACHE_TAG', ''),
 ];

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -71,8 +71,8 @@ class OauthMiddleware
 
     private function cacheGet(string $key): mixed
     {
-        if (Cache::supportsTags()) {
-            return Cache::tags([config('salla-oauth.cache-tag', 'salla-oauth')])->get($key);
+        if (Cache::supportsTags() && config('salla-oauth.cache-tag')) {
+            return Cache::tags([config('salla-oauth.cache-tag')])->get($key);
         }
 
         return Cache::get($key);
@@ -80,8 +80,8 @@ class OauthMiddleware
 
     private function cachePut(string $key, mixed $value, \DateTimeInterface $ttl): bool
     {
-        if (Cache::supportsTags()) {
-            return Cache::tags([config('salla-oauth.cache-tag', 'salla-oauth')])->put($key, $value, $ttl);
+        if (Cache::supportsTags() && config('salla-oauth.cache-tag')) {
+            return Cache::tags([config('salla-oauth.cache-tag')])->put($key, $value, $ttl);
         }
 
         return Cache::put($key, $value, $ttl);

--- a/test/OauthMiddlewareTest.php
+++ b/test/OauthMiddlewareTest.php
@@ -160,6 +160,7 @@ class OauthMiddlewareTest extends TestCase
     {
         // Use array cache which supports tags
         config(['cache.default' => 'array']);
+        config(['salla-oauth.cache-tag' => 'salla-oauth']);
         Cache::flush();
 
         $this->setupMockSalla();

--- a/test/OauthMiddlewareTest.php
+++ b/test/OauthMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace Salla\OAuth2\Client\Test;
 
+use Illuminate\Support\Facades\Cache;
 use League\OAuth2\Client\Token\AccessToken;
 use Salla\OAuth2\Client\Contracts\SallaOauth;
 use Salla\OAuth2\Client\Http\OauthMiddleware;
@@ -153,5 +154,80 @@ class OauthMiddlewareTest extends TestCase
 
         $response = $this->makeAuthRequest('hello/user-order-read-scope');
         $response->assertStatus(401);
+    }
+
+    public function testCacheUsesTagsWhenSupported()
+    {
+        // Use array cache which supports tags
+        config(['cache.default' => 'array']);
+        Cache::flush();
+
+        $this->setupMockSalla();
+
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+
+        // Verify cache was set with tags
+        $cacheKey = config('salla-oauth.cache-prefix') . '.foobar';
+        $cachedData = Cache::tags([config('salla-oauth.cache-tag', 'salla-oauth')])->get($cacheKey);
+
+        $this->assertNotNull($cachedData);
+        $this->assertArrayHasKey('data', $cachedData);
+    }
+
+    public function testCacheWorksWithoutTagsSupport()
+    {
+        // Use file cache which doesn't support tags
+        config(['cache.default' => 'file']);
+        Cache::flush();
+
+        $this->setupMockSalla();
+
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+
+        // Verify cache was set without tags
+        $cacheKey = config('salla-oauth.cache-prefix') . '.foobar';
+        $cachedData = Cache::get($cacheKey);
+
+        $this->assertNotNull($cachedData);
+        $this->assertArrayHasKey('data', $cachedData);
+    }
+
+    public function testCacheTagConfigIsUsed()
+    {
+        // Use array cache with custom tag
+        config(['cache.default' => 'array']);
+        config(['salla-oauth.cache-tag' => 'custom-oauth-tag']);
+        Cache::flush();
+
+        $this->setupMockSalla();
+
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+
+        // Verify cache uses custom tag
+        $cacheKey = config('salla-oauth.cache-prefix') . '.foobar';
+        $cachedData = Cache::tags(['custom-oauth-tag'])->get($cacheKey);
+
+        $this->assertNotNull($cachedData);
+    }
+
+    public function testCachedUserWithTagsSkipsApiCall()
+    {
+        // Use array cache which supports tags
+        config(['cache.default' => 'array']);
+        Cache::flush();
+
+        $this->setupMockSalla();
+
+        // First request - should call API and cache
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
+
+        // Second request - should use cache, not call API again
+        // (setupMockSalla expects exactly once, so if this fails, it means API was called twice)
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(200)->assertSeeText('hello 12345');
     }
 }


### PR DESCRIPTION
This pull request improves how OAuth user data is cached in the application by adding support for cache tags, making the caching behavior more flexible and robust. It introduces new helper methods to handle cache retrieval and storage, updates the configuration to allow customization of the cache tag, and adds comprehensive tests to verify the new behavior.

**Caching improvements:**

* Added a new `cache-tag` configuration option in `salla-oauth.php` to allow specifying the cache tag used for OAuth-related cache entries.
* Refactored `OauthMiddleware` to use new `cacheGet` and `cachePut` helper methods that utilize cache tags when supported, falling back to standard cache methods otherwise. [[1]](diffhunk://#diff-e0810e0a11d32afde07ed0f2a4ef27e8c534e2fb9765efd5334e9cbbac0a614fL28-R28) [[2]](diffhunk://#diff-e0810e0a11d32afde07ed0f2a4ef27e8c534e2fb9765efd5334e9cbbac0a614fL53-R53) [[3]](diffhunk://#diff-e0810e0a11d32afde07ed0f2a4ef27e8c534e2fb9765efd5334e9cbbac0a614fR71-R88)

**Testing enhancements:**

* Added tests to `OauthMiddlewareTest.php` to verify caching works with and without tag support, ensures the custom cache tag config is respected, and confirms that cached users prevent unnecessary API calls.
* Updated the test file to import the `Cache` facade, enabling the new tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR introduces cache tag support for OAuth user data caching, improving cache management capabilities. The implementation adds a configurable `cache-tag` option that allows grouping OAuth cache entries for bulk invalidation.

**Key Changes:**
- Added `cache-tag` configuration option (defaults to empty string, disabling tags by default)
- Refactored `OauthMiddleware` to use new `cacheGet` and `cachePut` helper methods that conditionally apply tags based on `Cache::supportsTags()` and config value
- Added comprehensive test coverage for tag-supported caches (array), non-tag caches (file), custom tag configuration, and cache hit behavior

**Implementation Notes:**
The implementation correctly checks both `Cache::supportsTags()` and the presence of a configured tag before applying tags. This ensures backward compatibility with cache drivers that don't support tags (like file cache) and allows users to opt-in by setting the `SALLA_OAUTH_CACHE_TAG` environment variable. The empty string default means tags are disabled by default, requiring explicit configuration to enable.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and backward compatible. It properly checks cache driver capabilities before applying tags, defaults to disabled state (empty string config), and includes comprehensive test coverage for multiple scenarios (tag support, no tag support, custom tags, and cache hits). The refactoring into helper methods improves maintainability without changing core behavior
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| config/salla-oauth.php | Added `cache-tag` configuration with empty string default, allowing optional cache tagging via environment variable |
| src/Http/OauthMiddleware.php | Refactored cache operations into helper methods with conditional tag support based on cache driver capabilities |
| test/OauthMiddlewareTest.php | Added comprehensive test coverage for cache tag functionality across different scenarios and cache drivers |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as OauthMiddleware
    participant CacheHelper as Cache Helper Methods
    participant Cache
    participant OAuth as SallaOAuth API

    Client->>Middleware: HTTP Request with Bearer Token
    Middleware->>Middleware: Extract token and build cache identifier
    
    Middleware->>CacheHelper: cacheGet(identifier)
    CacheHelper->>Cache: Check supportsTags() and config
    
    alt Cache driver supports tags AND cache-tag configured
        Cache-->>CacheHelper: Retrieve using tags
    else Cache driver does not support tags OR no cache-tag
        Cache-->>CacheHelper: Retrieve without tags
    end
    
    CacheHelper-->>Middleware: Return cached data or null
    
    alt Data exists in cache
        Middleware->>Client: Process request with cached user
    else Cache miss
        Middleware->>OAuth: Fetch user details from API
        OAuth-->>Middleware: Return user data
        
        Middleware->>CacheHelper: cachePut(identifier, data, expiration)
        CacheHelper->>Cache: Check supportsTags() and config
        
        alt Cache driver supports tags AND cache-tag configured
            Cache-->>CacheHelper: Store with tags
        else Cache driver does not support tags OR no cache-tag
            Cache-->>CacheHelper: Store without tags
        end
        
        Middleware->>Client: Process request with fresh user
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->