### PR TITLE
feat(DPD-0000): Upgrade Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     "require": {
         "php": "^8.1|^8.3",
         "league/oauth2-client": "^2.0",
-        "illuminate/support": "^9.0|^10.0|^11.0"
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "laravel/framework": "^9.0|^10.0|^11.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "squizlabs/php_codesniffer": "^2.0 || ^3.0"
     },

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -48,7 +48,8 @@ class OauthMiddleware
 
         $this->validateScopes($scopes);
 
-        $exception_at = now()->diffInSeconds($this->user->getExpiredAt());
+        // Carbon 3: diffInSeconds returns a signed float; force non-negative int for cache TTL.
+        $exception_at = (int) abs(now()->diffInSeconds($this->user->getExpiredAt()));
 
         $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 


### PR DESCRIPTION
Widens composer constraints (illuminate/support, laravel/framework, orchestra/testbench) to add Laravel 12 support. Also fixes a Carbon 3 compatibility issue in OauthMiddleware: diffInSeconds now returns a signed float (was unsigned int in Carbon 2), so we cast to abs(int) before passing it to addSeconds() for cache TTL.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Laravel 12 support by widening the `illuminate/support`, `laravel/framework`, and `orchestra/testbench` version constraints in `composer.json`, and fixes a Carbon 3 compatibility issue in `OauthMiddleware` where `diffInSeconds` now returns a signed float instead of an unsigned integer. Issues flagged in prior review rounds (PHPUnit/testbench constraint mismatch, expired-token re-caching via `abs()`) remain unresolved.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with low risk; the Carbon 3 fix is correct for non-expired tokens, and the version widening is straightforward.

Changes are small and targeted. The Carbon 3 fix is behaviorally correct for the happy path but lacks a regression test for the critical caching logic, warranting a confidence reduction per repo testing standards. Two pre-existing issues flagged in prior review threads (PHPUnit constraint incompatibility and expired-token re-caching) remain open.

src/Http/OauthMiddleware.php — Carbon 3 TTL fix lacks test coverage; composer.json — phpunit constraint still incompatible with orchestra/testbench ^10.0.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/Http/OauthMiddleware.php | Carbon 3 fix applies abs((int)…) to diffInSeconds for a non-negative cache TTL; no new test covers the changed behavior. |
| composer.json | Widens illuminate/support, laravel/framework, and orchestra/testbench to include Laravel 12 / testbench 10; phpunit constraint (^8.0|^9.0) incompatible with testbench ^10.0 (requires PHPUnit 11.x) remains unaddressed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Token present?}
    B -- No --> C[abort 401]
    B -- Yes --> D{Cache hit?}
    D -- Yes --> E[Load user from cache]
    E --> F[Validate Scopes]
    F --> G[Pass to next handler]
    D -- No --> H[Fetch user from OAuth provider]
    H --> I[Validate Scopes]
    I --> J[Compute TTL with Carbon 3 fix]
    J --> K[Store user in cache with TTL]
    K --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/Http/OauthMiddleware.php
Line: 52

Comment:
**No regression test for Carbon 3 behavioral change**

The `diffInSeconds` fix is a runtime behavior change (signed float vs unsigned int) that is not covered by any new or updated test. On a platform processing billions of requests per month, this caching path is critical and should have a test that exercises both the valid-token and expired-token TTL calculation to prevent silent regressions on future Carbon/Laravel upgrades.

**Rule Used:** All new code changes must include comprehensive au... ([source](https://app.greptile.com/review/custom-context?memory=66cc2964-cae6-4fd6-b237-b85e614f3799))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: trigger rebuild"](https://github.com/sallaapp/oauth2-merchant/commit/e489b3cf55bdd43cd89ef4571436cecf60551574) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29697415)</sub>

**Context used:**

- Rule used - All new code changes must include comprehensive au... ([source](https://app.greptile.com/review/custom-context?memory=66cc2964-cae6-4fd6-b237-b85e614f3799))

<!-- /greptile_comment -->