### PR TITLE
feat(CPD-29680): Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     "require": {
         "php": "^8.1|^8.3",
         "league/oauth2-client": "^2.0",
-        "illuminate/support": "^9.0|^10.0|^11.0"
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "laravel/framework": "^9.0|^10.0|^11.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "squizlabs/php_codesniffer": "^2.0 || ^3.0"
     },

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -48,15 +48,13 @@ class OauthMiddleware
 
         $this->validateScopes($scopes);
 
-        // diffInSeconds defaults to absolute on Carbon 2 (Laravel 9/10); pass false so an expired
-        // token yields a negative value (<= 0) and is rejected consistently on Carbon 2 and 3.
+        // diffInSeconds defaults to absolute on Carbon 2 (Laravel 9/10); pass false for a signed
+        // diff so an already-expired token is never cached with a positive TTL (Carbon 2 and 3).
         $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt(), false);
 
-        if ($exception_at <= 0) {
-            abort(401, 'Unauthorized Access');
+        if ($exception_at > 0) {
+            $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
         }
-
-        $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 
         return $this->nextRequest($next, $request);
     }

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -52,10 +52,6 @@ class OauthMiddleware
         // diff so an already-expired token yields <= 0 and is rejected (consistent on Carbon 2/3).
         $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt(), false);
 
-        if ($exception_at <= 0) {
-            abort(401, 'Unauthorized Access');
-        }
-
         $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 
         return $this->nextRequest($next, $request);

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -49,12 +49,14 @@ class OauthMiddleware
         $this->validateScopes($scopes);
 
         // diffInSeconds defaults to absolute on Carbon 2 (Laravel 9/10); pass false for a signed
-        // diff so an already-expired token is never cached with a positive TTL (Carbon 2 and 3).
+        // diff so an already-expired token yields <= 0 and is rejected (consistent on Carbon 2/3).
         $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt(), false);
 
-        if ($exception_at > 0) {
-            $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
+        if ($exception_at <= 0) {
+            abort(401, 'Unauthorized Access');
         }
+
+        $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 
         return $this->nextRequest($next, $request);
     }

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -48,8 +48,9 @@ class OauthMiddleware
 
         $this->validateScopes($scopes);
 
-        // Carbon 3: diffInSeconds is signed; an already-expired token yields <= 0 — reject it.
-        $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt());
+        // diffInSeconds defaults to absolute on Carbon 2 (Laravel 9/10); pass false so an expired
+        // token yields a negative value (<= 0) and is rejected consistently on Carbon 2 and 3.
+        $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt(), false);
 
         if ($exception_at <= 0) {
             abort(401, 'Unauthorized Access');

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -48,7 +48,12 @@ class OauthMiddleware
 
         $this->validateScopes($scopes);
 
-        $exception_at = now()->diffInSeconds($this->user->getExpiredAt());
+        // Carbon 3: diffInSeconds is signed; an already-expired token yields <= 0 — reject it.
+        $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt());
+
+        if ($exception_at <= 0) {
+            abort(401, 'Unauthorized Access');
+        }
 
         $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 

--- a/src/Http/OauthMiddleware.php
+++ b/src/Http/OauthMiddleware.php
@@ -52,6 +52,10 @@ class OauthMiddleware
         // diff so an already-expired token yields <= 0 and is rejected (consistent on Carbon 2/3).
         $exception_at = (int) now()->diffInSeconds($this->user->getExpiredAt(), false);
 
+        if ($exception_at <= 0) {
+            abort(401, 'Unauthorized Access');
+        }
+
         $this->cachePut($cacheKey, ['data' => $this->user->toArray()], now()->addSeconds($exception_at));
 
         return $this->nextRequest($next, $request);

--- a/test/OauthMiddlewareTest.php
+++ b/test/OauthMiddlewareTest.php
@@ -42,7 +42,7 @@ class OauthMiddlewareTest extends TestCase
                 'context' => [
                     'app' => '123',
                     'scope' => 'orders.read products.read',
-                    'exp' => 1721326955
+                    'exp' => time() + 3600
                 ]
             ]
         ];
@@ -146,7 +146,8 @@ class OauthMiddlewareTest extends TestCase
     public function testCachedUser()
     {
         $userData = $this->userData;
-        $userData['data']['context'] = null;
+        // Keep a valid (future) exp so the user is cached; drop the scope so the scoped route is denied.
+        $userData['data']['context']['scope'] = '';
         $this->setupMockSalla($userData);
 
         $response = $this->makeAuthRequest('hello/user');

--- a/test/OauthMiddlewareTest.php
+++ b/test/OauthMiddlewareTest.php
@@ -102,6 +102,17 @@ class OauthMiddlewareTest extends TestCase
         $response->assertStatus(401);
     }
 
+    public function testRejectsExpiredToken()
+    {
+        $userData = $this->userData;
+        $userData['data']['context']['exp'] = time() - 3600; // already expired
+
+        $this->setupMockSalla($userData);
+
+        $response = $this->makeAuthRequest('hello/user');
+        $response->assertStatus(401);
+    }
+
     public function testAddsUserinfoToRequest()
     {
         $this->setupMockSalla();


### PR DESCRIPTION
Laravel 12 support — re-cut fresh from master under CPD-29680 (supersedes DPD-16924 #41).

- Widen constraints for Laravel 12: `illuminate/support` +`^12.0`, `laravel/framework` +`^12.0`, `orchestra/testbench` +`^9.0|^10.0`.
- Fix Carbon 3 signed `diffInSeconds`: an already-expired (or clock-skewed) resource-owner token now returns `401` instead of being cached with a positive TTL produced by `abs()`.













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Laravel 12 compatibility is added while preserving support for earlier Laravel releases.
- Widens Illuminate, Laravel Framework, and Testbench constraints.
- Uses a signed Carbon difference and rejects resource owners whose expiration is non-positive.
- Adds an expired-token regression test and updates time-sensitive fixtures.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| composer.json | Widens package and development dependency constraints for Laravel 12 and corresponding Testbench releases. |
| src/Http/OauthMiddleware.php | Makes token-expiry calculation signed across Carbon versions and rejects non-positive lifetimes before caching or forwarding. |
| test/OauthMiddlewareTest.php | Future-dates shared fixtures and adds focused coverage proving expired resource owners receive a 401 response. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Protected request] --> B{User cached?}
  B -- Yes --> C[Validate scopes]
  B -- No --> D[Resolve resource owner]
  D --> E[Validate scopes]
  E --> F[Compute signed expiry TTL]
  F --> G{TTL positive?}
  G -- No --> H[Return 401]
  G -- Yes --> I[Cache user until expiry]
  C --> J[Attach user and continue]
  I --> J
```
</details>

<sub>Reviews (7): Last reviewed commit: ["Collect of Commits"](https://github.com/sallaapp/oauth2-merchant/commit/70c04d22c1a84569e3d6cad085e70accb7ddcda0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55135995)</sub>

**Context used:**

- Rule used - What: Require every success/error/validation messa... ([source](https://app.greptile.com/salla/-/custom-context?memory=07e5600d-8b53-4768-bc49-608459c57bf8))
- Knowledge Base — [OAuth request authentication](https://app.greptile.com/salla/-/custom-context/knowledge-base/sallaapp/oauth2-merchant/-/docs/oauth-request-authentication.md)

<!-- /greptile_comment -->